### PR TITLE
Make raven-cron work with commands that require options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,7 @@ release:
 	python setup.py sdist register upload
 	python2.6 setup.py bdist_egg register upload
 	python2.7 setup.py bdist_egg register upload
+
+test:
+	@pip install pytest mock
+	py.test -v tests/

--- a/raven_cron/runner.py
+++ b/raven_cron/runner.py
@@ -63,9 +63,6 @@ def run(args=argv[1:]):
 
 class CommandReporter(object):
     def __init__(self, cmd, dsn):
-        if len(cmd) <= 1:
-            cmd = cmd[0]
-
         self.dsn = dsn
         self.command = cmd
         self.client = None
@@ -74,7 +71,7 @@ class CommandReporter(object):
         buf = TemporaryFile()
         start = time()
 
-        exit_status = call(self.command, stdout=buf, stderr=buf, shell=True)
+        exit_status = call(self.command, stdout=buf, stderr=buf)
         
         if exit_status > 0:
             elapsed = int((time() - start) * 1000)

--- a/tests/test_command_reporter.py
+++ b/tests/test_command_reporter.py
@@ -1,0 +1,22 @@
+import mock
+from raven_cron.runner import CommandReporter
+
+
+@mock.patch('raven_cron.runner.Client')
+def test_command_reporter_accepts_parameters(ClientMock):
+    reporter = CommandReporter(['date', '--invalid-option'], 'http://testdsn')
+
+    reporter.run()
+
+    client = ClientMock()
+    assert client.captureMessage.called
+
+
+@mock.patch('raven_cron.runner.Client')
+def test_command_reporter_works_with_no_params_commands(ClientMock):
+    reporter = CommandReporter(['date'], 'http://testdsn')
+
+    reporter.run()
+
+    client = ClientMock()
+    assert not client.captureMessage.called


### PR DESCRIPTION
At the moment raven-cron does not work with commands that require options.