### PR TITLE
Write to stderr if sentry gives errors

### DIFF
--- a/raven_cron/runner.py
+++ b/raven_cron/runner.py
@@ -74,6 +74,10 @@ class CommandReporter(object):
         buf = TemporaryFile()
         start = time()
 
+        # Print something on stdout if raven gives an error
+        import logging
+        logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s")
+
         exit_status = call(self.command, stdout=buf, stderr=buf, shell=True)
         
         if exit_status > 0:


### PR DESCRIPTION
Without this only:

    No handlers could be found for logger "sentry.errors"

is printed.