### PR TITLE
Fix multi args

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ SENTRY_DSN=https://<your_key>:<your_secret>@app.getsentry.com/<your_project_id>
 @reboot raven-cron ./my-process
 ```
 
+Use `--` if the script takes options which may confuse `raven-cron`:
+
+    raven-cron -- ./my-process -x -y -z
+
 Misc
 ----
 

--- a/raven_cron/runner.py
+++ b/raven_cron/runner.py
@@ -65,6 +65,9 @@ class CommandReporter(object):
     def __init__(self, cmd, dsn):
         if len(cmd) <= 1:
             cmd = cmd[0]
+            self.shell = True
+        else:
+            self.shell = False
 
         self.dsn = dsn
         self.command = cmd
@@ -74,7 +77,7 @@ class CommandReporter(object):
         buf = TemporaryFile()
         start = time()
 
-        exit_status = call(self.command, stdout=buf, stderr=buf, shell=True)
+        exit_status = call(self.command, stdout=buf, stderr=buf, shell=self.shell)
         
         if exit_status > 0:
             elapsed = int((time() - start) * 1000)


### PR DESCRIPTION
The command:

    raven-cron -- python -c "omg an error"

hangs forever. In general you can't use options: only the first argument is actually executed by the shell.
