### PR TITLE
Send the entire message on sentry

### DIFF
--- a/raven_cron/runner.py
+++ b/raven_cron/runner.py
@@ -99,7 +99,7 @@ class CommandReporter(object):
         message="Command \"%s\" failed" % (self.command,)
 
         if self.client is None:
-            self.client = Client(dsn=self.dsn)
+            self.client = Client(dsn=self.dsn, string_max_length=MAX_MESSAGE_SIZE)
 
         self.client.captureMessage(
             message,


### PR DESCRIPTION
The client by default truncates the message to the first 400 chars (see
https://github.com/getsentry/sentry/issues/775).